### PR TITLE
fix(git-standup): use '/usr/bin/env bash'

### DIFF
--- a/git-standup
+++ b/git-standup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 AUTHOR=${AUTHOR:="`git config user.name`"}
 


### PR DESCRIPTION
Usage of `[[` is undefined in POSIX sh